### PR TITLE
Fixed the structure so it works in blender 2.8.2a

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,16 +14,24 @@ bl_info = {
   "author": " M. Heitzler and H. R. Baer",
   "blender": (2,80,0),
   "version": (1,0,0),
-  "location": "File>Import-Export",
+  "location": "File > Import > ASCII Grid (.asc)",
   "description": "Import meshes in ASCII Grid file format",
-  "category": "Import-Export"
+  "warning": "",
+  "wiki_url": "https://github.com/hrbaer/Blender-ASCII-Grid-Import",
+  "tracker_url": "https://github.com/hrbaer/Blender-ASCII-Grid-Import/issues",
+  "support": "COMMUNITY",
+  "category": "Import-Export", 
+    
 }
 
 import bpy
 import os
 import math
+from bpy_extras.io_utils import ImportHelper
 
-class ImportAsciiGrid(bpy.types.Operator):
+_isBlender280 = bpy.app.version[1] >= 80
+
+class ImportAsciiGrid(bpy.types.Operator, ImportHelper):
   bl_idname = "import_grid_format.asc"
   bl_label = "Import ASCII Grid"
   bl_options = {'PRESET'}
@@ -31,6 +39,11 @@ class ImportAsciiGrid(bpy.types.Operator):
   filename_ext = ".asc";
 
   filepath = bpy.props.StringProperty(subtype="FILE_PATH")
+
+  filter_glob = bpy.props.StringProperty(
+      default="*.asc",
+      options={"HIDDEN"},
+  )
 
   @classmethod
   def poll(cls, context):
@@ -102,9 +115,14 @@ class ImportAsciiGrid(bpy.types.Operator):
 
     return {'FINISHED'}
 
+  def draw(self, context):
+      layout = self.layout
+
   def invoke(self, context, event):
-    context.window_manager.fileselect_add(self)
-    return {'RUNNING_MODAL'}
+    #context.window_manager.fileselect_add(self)
+    #return {'RUNNING_MODAL'}
+    return super().invoke(context, event)
+
 
 def menu_func(self, context):
   self.layout.operator(ImportAsciiGrid.bl_idname, text="ASCII Grid (.asc)")
@@ -112,13 +130,17 @@ def menu_func(self, context):
 
 def register():
     bpy.utils.register_class(ImportAsciiGrid)
-    bpy.types.TOPBAR_MT_file_import.append(menu_func)
-    
+    if _isBlender280:
+        bpy.types.TOPBAR_MT_file_import.append(menu_func)
+    else:
+        bpy.types.INFO_MT_file_import.append(menu_func)
+
 def unregister():
     bpy.utils.unregister_class(ImportAsciiGrid)
-    bpy.types.TOPBAR_MT_file_import.remove(menu_func)
+    if _isBlender280:
+        bpy.types.TOPBAR_MT_file_import.remove(menu_func)
+    else:
+        bpy.types.INFO_MT_file_import.remove(menu_func)
   
 if __name__ == "__main__":
   register()
-
-

--- a/__init__.py
+++ b/__init__.py
@@ -10,18 +10,17 @@
 # ETH Zurich
 
 bl_info = {
-  "name": "Import ASCII Grid",
+  "name": "Import ASCII (.asc)",
   "author": " M. Heitzler and H. R. Baer",
   "blender": (2,80,0),
-  "version": (1,0,0),
-  "location": "File > Import > ASCII Grid (.asc)",
+  "version": (1,0, 1),
+  "location": "File > Import > ASCII (.asc)",
   "description": "Import meshes in ASCII Grid file format",
   "warning": "",
   "wiki_url": "https://github.com/hrbaer/Blender-ASCII-Grid-Import",
   "tracker_url": "https://github.com/hrbaer/Blender-ASCII-Grid-Import/issues",
   "support": "COMMUNITY",
-  "category": "Import-Export", 
-    
+  "category": "Import-Export",
 }
 
 import bpy
@@ -31,8 +30,8 @@ from bpy_extras.io_utils import ImportHelper
 
 _isBlender280 = bpy.app.version[1] >= 80
 
-class ImportAsciiGrid(bpy.types.Operator, ImportHelper):
-  bl_idname = "import_grid_format.asc"
+class ImportGrid(bpy.types.Operator, ImportHelper):
+  bl_idname = "import_scene.asc"
   bl_label = "Import ASCII Grid"
   bl_options = {'PRESET'}
 
@@ -125,18 +124,18 @@ class ImportAsciiGrid(bpy.types.Operator, ImportHelper):
 
 
 def menu_func(self, context):
-  self.layout.operator(ImportAsciiGrid.bl_idname, text="ASCII Grid (.asc)")
+  self.layout.operator(ImportGrid.bl_idname, text="ASCII Grid (.asc)")
 
 
 def register():
-    bpy.utils.register_class(ImportAsciiGrid)
+    bpy.utils.register_class(ImportGrid)
     if _isBlender280:
         bpy.types.TOPBAR_MT_file_import.append(menu_func)
     else:
         bpy.types.INFO_MT_file_import.append(menu_func)
 
 def unregister():
-    bpy.utils.unregister_class(ImportAsciiGrid)
+    bpy.utils.unregister_class(ImportGrid)
     if _isBlender280:
         bpy.types.TOPBAR_MT_file_import.remove(menu_func)
     else:


### PR DESCRIPTION
Hello,

Friday I try to use your plugin in Blender 2.8.2a, but doesn't work. I poke a little with the code,
and do some modifications on it in order to work:

* renamed the file to __init__.py so it becomes compatible
* "fixed" the open dialog, so it is filtered and only shows the .asc files.
* changed the register() / unregister() functions, so it becomes compatible.

Long in short, it now works on blender 2.8.2.a
Thanks for your awesome work!


[Blender-ASCII-Grid-Import-master.zip](https://github.com/hrbaer/Blender-ASCII-Grid-Import/files/4496267/Blender-ASCII-Grid-Import-master.zip)
